### PR TITLE
Support for Query String through the command line arguments.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,6 +10,7 @@ Options
   -?, -h, --help
   -u, --uri=VALUE            REQUIRED: The URI you want to call
   -m, --method=VALUE         The HTTP method. Default is GET
+  -q, --querystring=VALUE    The data to be passed. Default is empty
   -i, --iterations=VALUE     Number of iterations to run, default is 1
   -t, --interval=VALUE       Iterval between each call in milliseconds, default is 10000
   -p, --postdata=VALUE       Path to file containing post data

--- a/src/WebStresser/HttpCallConfiguration.cs
+++ b/src/WebStresser/HttpCallConfiguration.cs
@@ -33,6 +33,7 @@ namespace WebStresser
 
         public bool Expect100Continue { get; set; }
         public bool UseNagleAlgorithm { get; set; }
+        public string QueryString { get; set; }
 
         public HttpCallConfiguration()
         {

--- a/src/WebStresser/Program.cs
+++ b/src/WebStresser/Program.cs
@@ -44,6 +44,8 @@ namespace WebStresser
                     builder.GetServiceUri)
                 .Add("m=|method=", "The HTTP method. Default is GET",
                     builder.GetHttpMethod)
+                .Add("q=|querystring=", "The data to be passed. Default is empty",
+                    option => configuration.QueryString = option ?? string.Empty)
                 .Add("i=|iterations=", "Number of iterations to run, default is 1",
                     builder.GetIterations)
                 .Add("t=|interval=", "Iterval between each call in milliseconds, default is 10000",
@@ -62,7 +64,6 @@ namespace WebStresser
                     builder.GetTimeout)
                 .Add("H:", "Add a header to the request. e.g: -H MyHeader=MyValue",
                     builder.AddHeader);
-
         }
 
         private static void SetShowHelp(string option)

--- a/src/WebStresser/RawHttpClient.cs
+++ b/src/WebStresser/RawHttpClient.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 
@@ -98,9 +98,10 @@ namespace WebStresser
             }
         }
 
-        private void ExecuteRequest() {
-
-            var webRequest = (HttpWebRequest)WebRequest.CreateDefault(configuration.ServiceUri);
+        private void ExecuteRequest()
+        {
+            var requestUri = new Uri(configuration.ServiceUri + configuration.QueryString);
+            var webRequest = (HttpWebRequest)WebRequest.CreateDefault(requestUri);
 
             foreach (var headerKey in configuration.Headers.Keys)
             {


### PR DESCRIPTION
Added support for Query String in options. The user can specify data to be passed by using either -q or -querystring. The query string is composed of a series of field-value pairs. For more than one field-value pairs quote the Query String with ". 

Usage: 

Single field-value pair: -q=?username=foo 
Multiple field-values pairs: -q="?username=foo&password=bar"
